### PR TITLE
Fix Bug Due to Changed Dictionary Ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ When you click "Mint Bitku" on the Bitku website it sends a transaction on the F
 
 # Development
 
-See [`docs/development.md`](https://github.com/docmarionum1/bitku/blob/main/docs/development.md) for 
+See [`docs/development.md`](https://github.com/docmarionum1/bitku/blob/main/docs/developing.md) for 
 information about setting this project up locally, testing, and deployment.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -32,6 +32,8 @@ TODO: Allow limit to be configured in sendTransaction in `lib/js/node_modules/fl
 1. [Create an account](https://docs.onflow.org/concepts/accessing-testnet/#account-creation-and-token-funding-requests) and update the address and keys for `testnet-bitku-account` in `flow.json`.
 2. Run `flow transactions send transactions/setup_fusd_vault.cdc --network=testnet --signer testnet-bitku-account`
 3. Deploy the contracts with `flow project deploy --network=testnet --update`
-4. Run `flow transactions send transactions/pre_mint.cdc --network=testnet --signer testnet-bitku-account --gas-limit 9999 8` 8 times to complete the pre-mint.
-5. From `web` run `npm run build` and then copy the files into the deployment repository and commit and push them to github.
+4. Run `for i in {1..32}; do flow transactions send transactions/pre_mint.cdc --network=testnet --signer testnet-bitku-account --gas-limit 9999 2; done` to complete the pre-mint.
+5. From `lib/js` run `npm run build` and then copy `build` into the deployment repository and commit and push them to github.
+6. To test on testnet, create a Blocto account and
+[fund it with FUSD](https://testnet-faucet.onflow.org/fund-account), then attempt to mint haikus.
 6. If `HaikuNFT` needs to be updated, replace the from `*.cdc` imports with the actual addresses and then update it with `flow accounts update-contract HaikuNFT contracts/HaikuNFT.cdc --network=testnet --signer testnet-bitku-account`

--- a/lib/js/.env.local.template
+++ b/lib/js/.env.local.template
@@ -11,3 +11,8 @@ REACT_APP_WALLET_DISCOVERY=http://localhost:3001/fcl/authn
 #REACT_APP_FLOW_NETWORK=testnet
 #REACT_APP_ACCESS_NODE=https://access-testnet.onflow.org
 #REACT_APP_WALLET_DISCOVERY=https://fcl-discovery.onflow.org/testnet/authn
+
+# Mainnet
+# REACT_APP_FLOW_NETWORK=mainnet
+# REACT_APP_ACCESS_NODE=https://access-mainnet-beta.onflow.org
+# REACT_APP_WALLET_DISCOVERY=https://fcl-discovery.onflow.org/authn

--- a/lib/js/src/config.js
+++ b/lib/js/src/config.js
@@ -23,7 +23,7 @@ if (process.env.REACT_APP_FLOW_NETWORK === "emulator") {
   FEATURED_ADDRESS = contract_address;
   LOGO_URL = "http://localhost:3000/logo512.png"
 } else if (process.env.REACT_APP_FLOW_NETWORK === "testnet") {
-  const contract_address = "0x15fa543552f2c1f0";
+  const contract_address = "0x824f612f78d34250";
   config()
     .put("0xFUNGIBLETOKENADDRESS", "0x9a0766d93b6608b7")
     .put("0xTOKENADDRESS", "0x7e60df042a9c0868")
@@ -34,7 +34,7 @@ if (process.env.REACT_APP_FLOW_NETWORK === "emulator") {
   FEATURED_ADDRESS = contract_address;
   LOGO_URL = "https://testnet.bitku.art/logo512.png"
 } else if (process.env.REACT_APP_FLOW_NETWORK === "mainnet") {
-  const contract_address = "0x3885d9d426d2ef5c";
+  const contract_address = "0x824f612f78d34250";
   config()
     .put("0xFUNGIBLETOKENADDRESS", "0xf233dcee88fe0abe")
     .put("0xTOKENADDRESS", "0x1654653399040a61")

--- a/lib/js/src/config.js
+++ b/lib/js/src/config.js
@@ -34,7 +34,7 @@ if (process.env.REACT_APP_FLOW_NETWORK === "emulator") {
   FEATURED_ADDRESS = contract_address;
   LOGO_URL = "https://testnet.bitku.art/logo512.png"
 } else if (process.env.REACT_APP_FLOW_NETWORK === "mainnet") {
-  const contract_address = "0x824f612f78d34250";
+  const contract_address = "";
   config()
     .put("0xFUNGIBLETOKENADDRESS", "0xf233dcee88fe0abe")
     .put("0xTOKENADDRESS", "0x1654653399040a61")

--- a/lib/js/src/config.js
+++ b/lib/js/src/config.js
@@ -1,16 +1,16 @@
-import {config} from "@onflow/fcl"
+import { config } from "@onflow/fcl"
 
 console.log(process.env);
 
 config()
   .put("accessNode.api", process.env.REACT_APP_ACCESS_NODE) // Configure FCL's Access Node
   .put("challenge.handshake", process.env.REACT_APP_WALLET_DISCOVERY) // Configure FCL's Wallet Discovery mechanism
-  //.put("0xProfile", process.env.REACT_APP_CONTRACT_PROFILE) // Will let us use `0xProfile` in our Cadence
+//.put("0xProfile", process.env.REACT_APP_CONTRACT_PROFILE) // Will let us use `0xProfile` in our Cadence
 
 export let FEATURED_ADDRESS = "";
 export let LOGO_URL = "";
-  
-  
+
+
 if (process.env.REACT_APP_FLOW_NETWORK === "emulator") {
   const contract_address = "0xf8d6e0586b0a20c7";
   config()
@@ -33,4 +33,15 @@ if (process.env.REACT_APP_FLOW_NETWORK === "emulator") {
 
   FEATURED_ADDRESS = contract_address;
   LOGO_URL = "https://testnet.bitku.art/logo512.png"
+} else if (process.env.REACT_APP_FLOW_NETWORK === "mainnet") {
+  const contract_address = "0x3885d9d426d2ef5c";
+  config()
+    .put("0xFUNGIBLETOKENADDRESS", "0xf233dcee88fe0abe")
+    .put("0xTOKENADDRESS", "0x1654653399040a61")
+    .put("0xNONFUNGIBLETOKENADDRESS", "0x1d7e57aa55817448")
+    .put("0xHAIKUNFTADDRESS", contract_address)
+    .put("0xFUSDADDRESS", "0x3c5959b568896393");
+
+  FEATURED_ADDRESS = contract_address;
+  LOGO_URL = "https://bitku.art/logo512.png"
 }


### PR DESCRIPTION
After deploying to mainnet, and running the pre-seed, I discovered that the haiku text was not being generated properly. I tracked the issue down to a change in the underlying dictionary implementation in Cadence: https://github.com/onflow/cadence/pull/1156

This change was released in [Cadence v0.20.0](https://github.com/onflow/cadence/releases/tag/v0.20.0), which was after my last end-to-end test before I submitted contracts for review in October. 

The bug was due to the fact that previously, I was relying on dictionaries to have a stable ordering when picking words. I did this as an optimization to reduce the amount of compute needed. In retrospect, I shouldn't have done this because the Cadence spec never guaranteed stable ordering 😅 

This change fixes that issue by working on unordered dictionaries. This comes at the cost of needing extra compute, so I reduced the pre-mint transactions down to do 2 at a time instead of 8. On testing, I didn't have any issues with this, and generating 1 haiku seems to fall well within the 9999 gas limit.

I verified this fix on testnet: https://testnet.bitku.art/